### PR TITLE
Type Families.

### DIFF
--- a/expander-system/app/expander-system.hs
+++ b/expander-system/app/expander-system.hs
@@ -1,0 +1,28 @@
+module Main where
+
+import qualified ListT as ListT
+import System.Environment (getArgs)
+
+import TransitionSystem
+import Mutex
+import Bottle
+import Philosophers
+
+main = do
+  args <- getArgs
+  let mode = head args
+
+  case mode of
+    "mutex" -> writeSpec "mutex-base" "" (first processes :: Mutex.Status) () processes
+            where processes = getProcesses args
+                  getProcesses (_:processCountString:_) = [0..((read processCountString :: Int) - 1)]
+                  getProcesses _ = [0..5]
+    "bottle" -> writeSpec "bottle" "" (first () :: Bottle.BottleState) capacity ()
+            where capacity = BottleState $ getCapacity args
+                  getCapacity (_:lString:rString:_) = ((read lString :: Int), (read rString :: Int))
+                  getCapacity _ = (3, 5)
+    "philosophers" -> writeSpec "modal" "constructs: t e\n" (first () :: Philosophers.Table) count ()
+            where count = getCount args
+                  getCount (_:countString:_) = (read countString :: Int)
+                  getCount _ = 5
+    _ -> putStrLn "Please specify a valid mode: mutex, bottle, philosophers"

--- a/expander-system/expander-system.cabal
+++ b/expander-system/expander-system.cabal
@@ -8,11 +8,22 @@ category:
 build-type:           Simple
 cabal-version:        >=1.10
 
-executable expander-system
-  main-is:              Main.hs
+library
+  exposed-modules:      TransitionSystem
+                      , Bottle
+                      , Mutex
+                      , Philosophers
   build-depends:        base >= 4.7 && < 5
                       , containers
                       , mtl
                       , list-t
   hs-source-dirs:       src
+  default-language:     Haskell2010
+
+executable expander-system
+  main-is:              expander-system.hs
+  build-depends:        base >= 4.7 && < 5
+                      , expander-system
+                      , list-t
+  hs-source-dirs:       app
   default-language:     Haskell2010

--- a/expander-system/src/Bottle.hs
+++ b/expander-system/src/Bottle.hs
@@ -1,15 +1,17 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
-
+{-# LANGUAGE TypeFamilies #-}
 module Bottle where
 
 import TransitionSystem
 
-type BottleState = (Int, Int)
+newtype BottleState = BottleState (Int, Int)
+    deriving (Show, Eq, Ord)
 
-instance SystemNode BottleState BottleState () where
+instance SystemNode BottleState where
+    type UserData BottleState = BottleState
+    type Start BottleState = ()
     toString state _ = show state
-    first _ = (0, 0)
-    transitions (l, r) (capacityLeft, capacityRight) = emptyLeft ++ fillLeft ++ emptyRight ++ fillRight ++ transferToLeft ++ transferToRight
+    first _ = BottleState (0, 0)
+    transitions (BottleState (l, r)) (BottleState (capacityLeft, capacityRight)) = map BottleState $ emptyLeft ++ fillLeft ++ emptyRight ++ fillRight ++ transferToLeft ++ transferToRight
       where
         emptyLeft
             | l > 0 = [(0, r)]

--- a/expander-system/src/Mutex.hs
+++ b/expander-system/src/Mutex.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Mutex where
 
@@ -19,7 +19,9 @@ toTuple status = (toList $ idle $ status, wait status, maybeToList $ critical $ 
     where maybeToList (Just x) = [x]
           maybeToList Nothing = []
 
-instance SystemNode Status () [Id] where
+instance SystemNode Status where
+    type UserData Status = ()
+    type Start Status = [Id]
     toString status _ = show . toTuple $ status
     first processes = Status { idle = fromList processes, wait = [], critical = Nothing }
     transitions status _ = waits ++ enters ++ leaves

--- a/expander-system/src/Philosophers.hs
+++ b/expander-system/src/Philosophers.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Philosophers where
 
@@ -21,7 +21,9 @@ setEating table id shouldEat = updateTable shouldEat (isEating table id)
           updateTable False True = table - (2 ^ id)
           updateTable _ _ = table
 
-instance SystemNode Table Int () where
+instance SystemNode Int where
+    type UserData Int = Int
+    type Start Int = ()
     toString table count = "(" ++ inner ++ ")"
         where inner = intercalate ", " (map label [0..(count - 1)])
               label id = if isEating table id then "e" else "t"


### PR DESCRIPTION
Changed to typical project structure (app folder, library should always be added to cabl file). Also removed instantiation of type synonyms. Should be always avoided.